### PR TITLE
강의 조회

### DIFF
--- a/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/controller/LectureController.java
+++ b/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/controller/LectureController.java
@@ -1,6 +1,7 @@
 package com.sudurukBackBack.Modu_Lecture.domain.lecture.controller;
 
 import com.sudurukBackBack.Modu_Lecture.domain.lecture.dto.request.LectureCreateRequestDto;
+import com.sudurukBackBack.Modu_Lecture.domain.lecture.dto.response.LectureResponseDto;
 import com.sudurukBackBack.Modu_Lecture.domain.lecture.entity.Lecture;
 import com.sudurukBackBack.Modu_Lecture.domain.lecture.service.LectureService;
 import jakarta.validation.Valid;

--- a/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/controller/LectureController.java
+++ b/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/controller/LectureController.java
@@ -42,5 +42,5 @@ public class LectureController {
         LectureResponseDto lecture = lectureService.getLecture(lecture_id);
         return ResponseEntity.ok(lecture);
     }
-    
+
 }

--- a/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/controller/LectureController.java
+++ b/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/controller/LectureController.java
@@ -37,4 +37,10 @@ public class LectureController {
         Lecture createdLecture = lectureService.createLecture(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdLecture);
     }
+    @GetMapping("/{lecture_id}")
+    public ResponseEntity<LectureResponseDto> getLecture(@PathVariable Long lecture_id) {
+        LectureResponseDto lecture = lectureService.getLecture(lecture_id);
+        return ResponseEntity.ok(lecture);
+    }
+    
 }

--- a/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/controller/LectureController.java
+++ b/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/controller/LectureController.java
@@ -5,6 +5,7 @@ import com.sudurukBackBack.Modu_Lecture.domain.lecture.dto.response.LectureRespo
 import com.sudurukBackBack.Modu_Lecture.domain.lecture.entity.Lecture;
 import com.sudurukBackBack.Modu_Lecture.domain.lecture.service.LectureService;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -16,15 +17,12 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/lectures")
+@RequiredArgsConstructor  // Lombok 자동 생성자 사용 → 불필요한 생성자 제거
 public class LectureController {
     private final LectureService lectureService;
 
-    public LectureController(LectureService lectureService) {
-        this.lectureService = lectureService;
-    }
-
     @PostMapping
-    public ResponseEntity<?> createLecture(@Valid @RequestBody LectureCreateRequestDto requestDto, @org.jetbrains.annotations.NotNull BindingResult bindingResult) {
+    public ResponseEntity<?> createLecture(@Valid @RequestBody LectureCreateRequestDto requestDto, BindingResult bindingResult) {
         // 유효성 검증 실패 시, 상세한 에러 메시지 반환
         if (bindingResult.hasErrors()) {
             Map<String, String> errors = new HashMap<>();
@@ -34,14 +32,15 @@ public class LectureController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
         }
 
-        // 강의 생성 요청을 서비스로 전달
+        //  강의 생성 요청을 서비스로 전달
         Lecture createdLecture = lectureService.createLecture(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdLecture);
     }
+
     @GetMapping("/{lecture_id}")
     public ResponseEntity<LectureResponseDto> getLecture(@PathVariable Long lecture_id) {
+        //  강의 상세 조회 (없는 강의일 경우 예외 발생 처리)
         LectureResponseDto lecture = lectureService.getLecture(lecture_id);
         return ResponseEntity.ok(lecture);
     }
-
 }

--- a/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/dto/response/LectureResponseDto.java
+++ b/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/dto/response/LectureResponseDto.java
@@ -1,0 +1,29 @@
+package com.sudurukBackBack.Modu_Lecture.domain.lecture.dto.response;
+
+import com.sudurukBackBack.Modu_Lecture.domain.lecture.entity.Lecture;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class LectureResponseDto {
+    private final Long lectureId;
+    private final Long userId;
+    private final String title;
+    private final String description;
+    private final String instructor;
+    private final int category;
+    private final int price;
+    private final LocalDateTime createdAt;
+
+    public LectureResponseDto(Lecture lecture) {
+        this.lectureId = lecture.getLectureId();
+        this.userId = lecture.getUserId();
+        this.title = lecture.getTitle();
+        this.description = lecture.getDescription();
+        this.instructor = lecture.getInstructor();
+        this.category = lecture.getCategory();
+        this.price = lecture.getPrice();
+        this.createdAt = lecture.getCreatedAt();
+    }
+}

--- a/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/dto/response/LectureResponseDto.java
+++ b/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/dto/response/LectureResponseDto.java
@@ -5,25 +5,26 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-@Getter
-public class LectureResponseDto {
-    private final Long lectureId;
-    private final Long userId;
-    private final String title;
-    private final String description;
-    private final String instructor;
-    private final int category;
-    private final int price;
-    private final LocalDateTime createdAt;
-
+public record LectureResponseDto(
+        Long lectureId,
+        Long userId,
+        String title,
+        String description,
+        String instructor,
+        int category,
+        int price,
+        LocalDateTime createdAt
+) {
     public LectureResponseDto(Lecture lecture) {
-        this.lectureId = lecture.getLectureId();
-        this.userId = lecture.getUserId();
-        this.title = lecture.getTitle();
-        this.description = lecture.getDescription();
-        this.instructor = lecture.getInstructor();
-        this.category = lecture.getCategory();
-        this.price = lecture.getPrice();
-        this.createdAt = lecture.getCreatedAt();
+        this(
+                lecture.getLectureId(),
+                lecture.getUserId(),
+                lecture.getTitle(),
+                lecture.getDescription(),
+                lecture.getInstructor(),
+                lecture.getCategory(),
+                lecture.getPrice(),
+                lecture.getCreatedAt()
+        );
     }
 }

--- a/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/dto/response/LectureResponseDto.java
+++ b/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/dto/response/LectureResponseDto.java
@@ -2,6 +2,7 @@ package com.sudurukBackBack.Modu_Lecture.domain.lecture.dto.response;
 
 import com.sudurukBackBack.Modu_Lecture.domain.lecture.entity.Lecture;
 import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
 
 import java.time.LocalDateTime;
 
@@ -15,7 +16,7 @@ public record LectureResponseDto(
         int price,
         LocalDateTime createdAt
 ) {
-    public LectureResponseDto(Lecture lecture) {
+    public LectureResponseDto(@NotNull Lecture lecture) {
         this(
                 lecture.getLectureId(),
                 lecture.getUserId(),

--- a/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/exception/LectureNotFoundException.java
+++ b/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/exception/LectureNotFoundException.java
@@ -1,4 +1,7 @@
 package com.sudurukBackBack.Modu_Lecture.domain.lecture.exception;
 
-public class LectureNotFoundException {
+public class LectureNotFoundException extends RuntimeException {
+    public LectureNotFoundException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/exception/LectureNotFoundException.java
+++ b/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/exception/LectureNotFoundException.java
@@ -1,7 +1,16 @@
 package com.sudurukBackBack.Modu_Lecture.domain.lecture.exception;
 
-public class LectureNotFoundException extends RuntimeException {
-    public LectureNotFoundException(String message) {
-        super(message);
+import org.springframework.http.HttpStatus;
+
+public final class LectureNotFoundException extends BasicException {
+
+    @Override
+    public int statusCode() {
+        return HttpStatus.NOT_FOUND.value();
+    }
+
+    @Override
+    public String errorMessage() {
+        return "강의를 찾을 수 없습니다.";
     }
 }

--- a/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/exception/LectureNotFoundException.java
+++ b/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/exception/LectureNotFoundException.java
@@ -1,5 +1,8 @@
 package com.sudurukBackBack.Modu_Lecture.domain.lecture.exception;
 
+import com.sudurukBackBack.Modu_Lecture.global.exception.BasicException;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.http.HttpStatus;
 
 public final class LectureNotFoundException extends BasicException {
@@ -9,6 +12,8 @@ public final class LectureNotFoundException extends BasicException {
         return HttpStatus.NOT_FOUND.value();
     }
 
+    @NotNull
+    @Contract(pure = true)
     @Override
     public String errorMessage() {
         return "강의를 찾을 수 없습니다.";

--- a/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/repository/LectureRepository.java
@@ -2,6 +2,8 @@ package com.sudurukBackBack.Modu_Lecture.domain.lecture.repository;
 
 import com.sudurukBackBack.Modu_Lecture.domain.lecture.entity.Lecture;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface LectureRepository extends JpaRepository<Lecture, Long> {
 }

--- a/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/service/LectureService.java
+++ b/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/service/LectureService.java
@@ -39,4 +39,12 @@ public class LectureService {
 
         return lectureRepository.save(lecture);
     }
+    //  강의 조회 메서드
+    @Transactional(readOnly = true)
+    public LectureResponseDto getLectureById(Long lectureId) {
+        Lecture lecture = lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 강의를 찾을 수 없습니다: " + lectureId));
+
+        return new LectureResponseDto(lecture);
+    }
 }

--- a/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/service/LectureService.java
+++ b/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/service/LectureService.java
@@ -1,8 +1,10 @@
 package com.sudurukBackBack.Modu_Lecture.domain.lecture.service;
 
 import com.sudurukBackBack.Modu_Lecture.domain.lecture.dto.request.LectureCreateRequestDto;
+import com.sudurukBackBack.Modu_Lecture.domain.lecture.dto.response.LectureResponseDto;
 import com.sudurukBackBack.Modu_Lecture.domain.lecture.entity.Lecture;
 import com.sudurukBackBack.Modu_Lecture.domain.lecture.entity.LectureStatus;
+import com.sudurukBackBack.Modu_Lecture.domain.lecture.exception.LectureNotFoundException;
 import com.sudurukBackBack.Modu_Lecture.domain.lecture.repository.LectureRepository;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
@@ -41,10 +43,10 @@ public class LectureService {
     }
     //  강의 조회 메서드
     @Transactional(readOnly = true)
-    public LectureResponseDto getLectureById(Long lectureId) {
+    public LectureResponseDto getLecture(Long lectureId) {
         Lecture lecture = lectureRepository.findById(lectureId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 강의를 찾을 수 없습니다: " + lectureId));
-
+                .orElseThrow(() -> new LectureNotFoundException("해당 강의를 찾을 수 없습니다: " + lectureId));
         return new LectureResponseDto(lecture);
     }
+
 }

--- a/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/service/LectureService.java
+++ b/src/main/java/com/sudurukBackBack/Modu_Lecture/domain/lecture/service/LectureService.java
@@ -10,10 +10,14 @@ import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
 
 @Service
+@RestController
+@RequestMapping("/lectures")
 @RequiredArgsConstructor
 public class LectureService {
 
@@ -45,7 +49,8 @@ public class LectureService {
     @Transactional(readOnly = true)
     public LectureResponseDto getLecture(Long lectureId) {
         Lecture lecture = lectureRepository.findById(lectureId)
-                .orElseThrow(() -> new LectureNotFoundException("해당 강의를 찾을 수 없습니다: " + lectureId));
+                .orElseThrow(LectureNotFoundException::new); //  변경된 코드
+
         return new LectureResponseDto(lecture);
     }
 


### PR DESCRIPTION
## 변경 사항
**강의 조회(GET /lectures/{lecture_id}) 기능 구현**
  - `LectureRepository.findById()`를 활용하여 강의 데이터 조회
  - `LectureNotFoundException`을 도입하여 존재하지 않는 강의 조회 시 예외 처리
  - `LectureResponseDto`를 추가하여 응답 데이터 반환 형식 정리


---


- [ ] 테스트 코드
- [ ] API 테스트 