### PR TITLE
refactor: env로 secret 관리

### DIFF
--- a/src/main/java/com/sudurukbackback/modulecture/ModuLectureApplication.java
+++ b/src/main/java/com/sudurukbackback/modulecture/ModuLectureApplication.java
@@ -1,16 +1,35 @@
 package com.sudurukbackback.modulecture;
 
+import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+
+import java.util.Objects;
 
 @EnableScheduling
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class ModuLectureApplication {
 
 	public static void main(String[] args) {
+
+		Dotenv dotenv = Dotenv.load();
+
+		// RDS 인증 정보 설정
+		System.setProperty("spring.datasource.url", Objects.requireNonNull(dotenv.get("RDS_URL")));
+		System.setProperty("spring.datasource.username", Objects.requireNonNull(dotenv.get("RDS_USERNAME")));
+		System.setProperty("spring.datasource.password", Objects.requireNonNull(dotenv.get("RDS_PASSWORD")));
+
+		// S3 인증 정보 설정
+		System.setProperty("cloud.aws.region", Objects.requireNonNull(dotenv.get("REGION")));
+		System.setProperty("cloud.aws.s3.bucket-name", Objects.requireNonNull(dotenv.get("BUCKET_NAME")));
+		System.setProperty("cloud.aws.credentials.access-key", Objects.requireNonNull(dotenv.get("ACCESS_KEY")));
+		System.setProperty("cloud.aws.credentials.secret-key", Objects.requireNonNull(dotenv.get("SECRET_KEY")));
+
 		SpringApplication.run(ModuLectureApplication.class, args);
+
+
 	}
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,24 +17,26 @@ spring:
     properties:
       hibernate.dialect: org.hibernate.dialect.MySQL8Dialect
 
-  datasource:
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
+  thymeleaf:
+    prefix: classpath:/templates/domain/
+    suffix: .html
+    mode: HTML
+    cache: false
+    encoding: UTF-8
 
-  #     AWS RDS DB 접속 정보
-  #     url: jdbc:mysql://${DB_ENDPOINT}:3306/modu_lecture?useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
-  #     username: ${DB_USERNAME}
-  #     password: ${DB_PASSWORD}
+  datasource:
+    url: ${spring.datasource.url}
+    username: ${spring.datasource.username}
+    password: ${spring.datasource.password}
+    driver-class-name: com.mysql.cj.jdbc.Driver
 
 cloud:
   aws:
-    region: 'ap-northeast-2'
+    region: ${cloud.aws.region}
     credentials:
-      access-key: '${access-key}'
-      secret-key: '${secret-key}'
+      access-key: ${cloud.aws.credentials.access-key}
+      secret-key: ${cloud.aws.credentials.secret-key}
     s3:
-      bucket-name: 'modu-s3-bucket'
+      bucket-name: ${cloud.aws.s3.bucket-name}
       video-prefix: 'videos/'
       image-prefix: 'images/'


### PR DESCRIPTION
## 변경 사항
[//]: # (이 PR에서 어떤점들이 변경되었는지 기술. 가급적이면 as-is, to-be를 활용해서 작성)

- develop에서 분화한 새로운 브랜치를 생성할 때마다 SpringBoot Application 실행을 위해 매번 인증 정보를 입력해줘야하는 상황.

- 따라서 기존에 JWT에서 사용하던 .env 파일에 인증 정보를 기입한다. (따라서 이미 의존성 정의된 상태)

- [x] env 파일 작성
- [x] Application 파일에서 env 읽어오기
- [x] application.yml에 적용
- [x] 연결 테스트