### PR TITLE
[#83] Category 엔티티 추가 및 Lecture 로직 수정

### DIFF
--- a/src/main/java/com/sudurukbackback/modulecture/domain/lecture/component/CategoryInitializr.java
+++ b/src/main/java/com/sudurukbackback/modulecture/domain/lecture/component/CategoryInitializr.java
@@ -1,0 +1,38 @@
+package com.sudurukbackback.modulecture.domain.lecture.component;
+
+import com.sudurukbackback.modulecture.domain.lecture.entity.Category;
+import com.sudurukbackback.modulecture.domain.lecture.repository.CategoryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+public class CategoryInitializr implements ApplicationRunner {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        List<String> categoryNames = Arrays.asList(
+                "프로그래밍", "데이터", "인공지능", "웹 개발", "디자인",
+                "사진", "음악", "미술", "언어", "역사",
+                "철학", "문학", "물리학", "화학", "생물학",
+                "심리학", "경영학", "마케팅", "경제학", "금융",
+                "의학", "영양학", "피트니스", "건강"
+        );
+
+        for (String name : categoryNames) {
+            // 이미 존재하는지 확인
+            if (!categoryRepository.existsByCategoryName(name)) {
+                Category category = new Category();
+                category.setCategoryName(name);
+                categoryRepository.save(category);
+            }
+        }
+    }
+}

--- a/src/main/java/com/sudurukbackback/modulecture/domain/lecture/controller/LectureController.java
+++ b/src/main/java/com/sudurukbackback/modulecture/domain/lecture/controller/LectureController.java
@@ -2,11 +2,14 @@ package com.sudurukbackback.modulecture.domain.lecture.controller;
 
 import com.sudurukbackback.modulecture.domain.lecture.dto.request.LectureCreateRequestDto;
 import com.sudurukbackback.modulecture.domain.lecture.dto.response.LectureResponseDto;
-import com.sudurukbackback.modulecture.domain.lecture.dto.response.LectureUpdateRequestDto;
+import com.sudurukbackback.modulecture.domain.lecture.dto.request.LectureUpdateRequestDto;
 import com.sudurukbackback.modulecture.domain.lecture.service.LectureService;
+import com.sudurukbackback.modulecture.domain.storage.service.ContentService;
+import com.sudurukbackback.modulecture.domain.user.entity.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -17,25 +20,60 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class LectureController {
     private final LectureService lectureService;
+    private final ContentService contentService;
 
-    // 강의 생성 (파일 포함)
+    /**
+     * 새로운 강의를 생성합니다. (파일 업로드 포함)
+     *
+     * @param request 강의 생성 요청 데이터를 담은 DTO 객체
+     * @param file 업로드할 파일 (선택 사항)
+     * @param auth 현재 인증된 사용자 정보를 담은 Authentication 객체
+     * @return 생성된 강의 정보를 담은 LectureResponseDto를 포함한 ResponseEntity
+     * @throws IOException 파일 처리 중 발생할 수 있는 예외
+     */
     @PostMapping
     public ResponseEntity<LectureResponseDto> createLecture(
-            @RequestPart("requestDto") @Valid LectureCreateRequestDto requestDto,
-            @RequestPart(value = "file", required = false) MultipartFile file) throws IOException {
+            @RequestPart("requestDto") @Valid LectureCreateRequestDto request,
+            @RequestPart(value = "file", required = false) MultipartFile file,
+            Authentication auth) throws IOException {
 
-        LectureResponseDto responseDto = lectureService.createLecture(requestDto, file);
-        return ResponseEntity.ok(responseDto);
+        // 현재 인증된 사용자의 id 가져오기
+        User user = (User) auth.getPrincipal();
+        Long userId = user.getId();
+
+        LectureResponseDto response = lectureService.createLecture(request, userId, file);
+        Long lectureId = response.getLectureId();
+
+        // contentService: uploadContent - S3에 파일 업로드 과정 진행
+        contentService.uploadContent(lectureId, file);
+
+        return ResponseEntity.ok(response);
     }
 
-    // 강의 상세 조회
+    /**
+     * 특정 강의의 상세 정보를 조회합니다.
+     *
+     * @param lecture_id 조회할 강의의 ID
+     * @return 조회된 강의 정보를 담은 LectureResponseDto를 포함한 ResponseEntity
+     */
     @GetMapping("/{lecture_id}")
     public ResponseEntity<LectureResponseDto> getLecture(@PathVariable Long lecture_id) {
         LectureResponseDto lecture = lectureService.getLecture(lecture_id);
+
+        // contentService: getContent - S3에서 video, image 조회 (추후 구현)
+
         return ResponseEntity.ok(lecture);
     }
 
-    // 강의 수정 (PATCH)
+    /**
+     * 특정 강의의 정보를 수정합니다.
+     *
+     * @param lecture_id 수정할 강의의 ID
+     * @param requestDto 강의 수정 요청 데이터를 담은 DTO 객체
+     * @param file 업로드할 파일 (선택 사항)
+     * @return 수정된 강의 정보를 담은 LectureResponseDto를 포함한 ResponseEntity
+     * @throws IOException 파일 처리 중 발생할 수 있는 예외
+     */
     @PatchMapping("/{lecture_id}")
     public ResponseEntity<LectureResponseDto> updateLecture(
             @PathVariable Long lecture_id,
@@ -46,10 +84,18 @@ public class LectureController {
         return ResponseEntity.ok(updatedLecture);
     }
 
-    // 강의 삭제 (파일 포함)
+    /**
+     * 특정 강의를 삭제합니다. (파일 삭제 포함)
+     *
+     * @param lecture_id 삭제할 강의의 ID
+     * @return 내용이 없는 응답(ResponseEntity<Void>)으로, HTTP 상태 코드는 204 No Content입니다.
+     */
     @DeleteMapping("/{lecture_id}")
     public ResponseEntity<Void> deleteLecture(@PathVariable Long lecture_id) {
         lectureService.deleteLecture(lecture_id);
+
+        // contentService: deleteContent - S3에서 video, image 삭제 (추후 구현)
+
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sudurukbackback/modulecture/domain/lecture/dto/request/LectureCreateRequestDto.java
+++ b/src/main/java/com/sudurukbackback/modulecture/domain/lecture/dto/request/LectureCreateRequestDto.java
@@ -26,7 +26,7 @@ public class LectureCreateRequestDto {
     private String description;
 
     @NotNull(message = "카테고리는 필수 입력값입니다.")
-    private List<Long> categoryIds; // List<Long> categoryIds 추가
+    private Long categoryId;
 
     @NotNull(message = "가격은 필수 입력값입니다.")
     @Min(value = 0, message = "가격은 0원 이상이어야 합니다.")

--- a/src/main/java/com/sudurukbackback/modulecture/domain/lecture/dto/request/LectureUpdateRequestDto.java
+++ b/src/main/java/com/sudurukbackback/modulecture/domain/lecture/dto/request/LectureUpdateRequestDto.java
@@ -1,4 +1,4 @@
-package com.sudurukbackback.modulecture.domain.lecture.dto.response;
+package com.sudurukbackback.modulecture.domain.lecture.dto.request;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -22,7 +22,7 @@ public class LectureUpdateRequestDto {
     @Size(max = 1000, message = "강의 설명은 최대 1000자까지 가능합니다.")
     private String description;
 
-    private List<Long> categoryIds; // List<Long> categoryIds 추가
+    private Long categoryId; // List<Long> categoryIds 추가
 
     @Min(value = 0, message = "가격은 0원 이상이어야 합니다.")
     @Max(value = 1000000, message = "가격은 최대 1,000,000원까지 설정할 수 있습니다.")

--- a/src/main/java/com/sudurukbackback/modulecture/domain/lecture/dto/response/LectureResponseDto.java
+++ b/src/main/java/com/sudurukbackback/modulecture/domain/lecture/dto/response/LectureResponseDto.java
@@ -10,24 +10,22 @@ import java.util.List;
 public class LectureResponseDto {
 
     private final Long lectureId;
-    private final Long userId;
     private final String title;
     private final String description;
-    private final List<Long> categoryIds;
+    private final Long categoryId;
     private final int price;
-    private final String videoUrl; //  비디오 URL 추가
-    private final String imageUrl; //  썸네일 이미지 URL 추가
+//    private final String videoUrl; //  비디오 URL 추가
+//    private final String imageUrl; //  썸네일 이미지 URL 추가
     private final LocalDateTime createdAt;
 
-    public LectureResponseDto(Lecture lecture, String videoUrl, String imageUrl) {
-        this.lectureId = lecture.getLectureId();
-        this.userId = lecture.getUserId();
+    public LectureResponseDto(Lecture lecture) {
+        this.lectureId = lecture.getId();
         this.title = lecture.getTitle();
         this.description = lecture.getDescription();
-        this.categoryIds = lecture.getCategoryIds();
+        this.categoryId = lecture.getCategoryId();
         this.price = lecture.getPrice();
-        this.videoUrl = videoUrl;
-        this.imageUrl = imageUrl;
+//        this.videoUrl = videoUrl;
+//        this.imageUrl = imageUrl;
         this.createdAt = lecture.getCreatedAt();
     }
 }

--- a/src/main/java/com/sudurukbackback/modulecture/domain/lecture/entity/Category.java
+++ b/src/main/java/com/sudurukbackback/modulecture/domain/lecture/entity/Category.java
@@ -1,0 +1,24 @@
+package com.sudurukbackback.modulecture.domain.lecture.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "category")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Column(nullable = false, unique = true)
+    private String categoryName;
+
+}

--- a/src/main/java/com/sudurukbackback/modulecture/domain/lecture/entity/CategoryRel.java
+++ b/src/main/java/com/sudurukbackback/modulecture/domain/lecture/entity/CategoryRel.java
@@ -1,0 +1,28 @@
+package com.sudurukbackback.modulecture.domain.lecture.entity;
+
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "categoryrel")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryRel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Column(nullable = false)
+    private Long lectureId;
+
+    @NotNull
+    @Column(nullable = false)
+    private Long categoryId;
+}

--- a/src/main/java/com/sudurukbackback/modulecture/domain/lecture/entity/Lecture.java
+++ b/src/main/java/com/sudurukbackback/modulecture/domain/lecture/entity/Lecture.java
@@ -4,12 +4,12 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Table(name = "lecture")
-@Getter
-@Setter
+@Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -17,7 +17,7 @@ public class Lecture {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long lectureId;
+    private Long id;
 
     @Column(nullable = false)
     private Long userId;
@@ -29,19 +29,10 @@ public class Lecture {
     private String description;
 
     @Column(nullable = false)
-    private String instructor;
-
-    @ElementCollection //형식으로 categoryIds 저장 가능
-    private List<Long> categoryIds;
+    private Long categoryId;
 
     @Column(nullable = false)
-    private int price; //  기본형 int 사용
-
-    @Column(nullable = true)
-    private String videoUrl; // 강의 영상 URL 추가
-
-    @Column(nullable = true)
-    private String imageUrl; // 썸네일 이미지 URL 추가
+    private int price;
 
     @Column(nullable = false)
     private LocalDateTime createdAt;
@@ -49,9 +40,4 @@ public class Lecture {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private LectureStatus status;
-
-    //  필요한 경우 개별 setter 메서드 추가 가능
-    @Setter
-    @Column(nullable = false)
-    private int duration; //  duration 필드 확인 및 추가
 }

--- a/src/main/java/com/sudurukbackback/modulecture/domain/lecture/repository/CategoryRepository.java
+++ b/src/main/java/com/sudurukbackback/modulecture/domain/lecture/repository/CategoryRepository.java
@@ -1,0 +1,10 @@
+package com.sudurukbackback.modulecture.domain.lecture.repository;
+
+import com.sudurukbackback.modulecture.domain.lecture.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long>  {
+    boolean existsByCategoryName(String categoryName);
+}

--- a/src/main/java/com/sudurukbackback/modulecture/domain/lecture/service/LectureService.java
+++ b/src/main/java/com/sudurukbackback/modulecture/domain/lecture/service/LectureService.java
@@ -2,7 +2,7 @@ package com.sudurukbackback.modulecture.domain.lecture.service;
 
 import com.sudurukbackback.modulecture.domain.lecture.dto.request.LectureCreateRequestDto;
 import com.sudurukbackback.modulecture.domain.lecture.dto.response.LectureResponseDto;
-import com.sudurukbackback.modulecture.domain.lecture.dto.response.LectureUpdateRequestDto;
+import com.sudurukbackback.modulecture.domain.lecture.dto.request.LectureUpdateRequestDto;
 import com.sudurukbackback.modulecture.domain.lecture.entity.Lecture;
 import com.sudurukbackback.modulecture.domain.lecture.exception.LectureNotFoundException;
 import com.sudurukbackback.modulecture.domain.lecture.repository.LectureRepository;
@@ -22,31 +22,32 @@ public class LectureService {
 
     //강의 생성 (S3 파일 업로드 포함)
     @Transactional
-    public LectureResponseDto createLecture(LectureCreateRequestDto requestDto, MultipartFile file) throws IOException {
+    public LectureResponseDto createLecture(LectureCreateRequestDto request, Long userId, MultipartFile file) throws IOException {
         // 강의 정보 DB 저장
         Lecture lecture = Lecture.builder()
-                .userId(requestDto.getUserId())
-                .title(requestDto.getTitle())
-                .description(requestDto.getDescription())
-                .categoryIds(requestDto.getCategoryIds()) //  변경된 categoryIds 적용
-                .price(requestDto.getPrice())
+                .userId(userId)
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .categoryId(request.getCategoryId())
+                .price(request.getPrice())
                 .createdAt(LocalDateTime.now())
                 .build();
 
         Lecture savedLecture = lectureRepository.save(lecture);
-        //Long lectureId = savedLecture.getLectureId(); //  저장 후 ID 획득
 
-        lectureRepository.save(savedLecture);
-
-        return new LectureResponseDto(savedLecture, null, null);
+        return new LectureResponseDto(savedLecture);
     }
+
     // 강의 상세 조회 (S3 파일 URL 포함)
     @Transactional(readOnly = true)
     public LectureResponseDto getLecture(Long lectureId) {
         Lecture lecture = lectureRepository.findById(lectureId)
                 .orElseThrow(() -> new LectureNotFoundException("해당 강의를 찾을 수 없습니다."));
 
-        return new LectureResponseDto(lecture, lecture.getVideoUrl(), lecture.getImageUrl());
+        // + contentService단의 조회 로직
+
+        // return new LectureResponseDto(lecture, lecture.getVideoUrl(), lecture.getImageUrl());
+        return new LectureResponseDto(lecture);
     }
 
     // 강의 수정 (PATCH)
@@ -61,14 +62,14 @@ public class LectureService {
         if (requestDto.getDescription() != null) {
             lecture.setDescription(requestDto.getDescription());
         }
-        if (requestDto.getCategoryIds() != null) {
-            lecture.setCategoryIds(requestDto.getCategoryIds());
+        if (requestDto.getCategoryId() != null) {
+            lecture.setCategoryId(requestDto.getCategoryId());
         }
         if (requestDto.getPrice() != null) {
             lecture.setPrice(requestDto.getPrice());
         }
 
-        return new LectureResponseDto(lecture, lecture.getVideoUrl(), lecture.getImageUrl());
+        return new LectureResponseDto(lecture);
     }
 
     // 강의 삭제 (S3 파일 삭제 포함)

--- a/src/main/java/com/sudurukbackback/modulecture/domain/storage/controller/ContentController.java
+++ b/src/main/java/com/sudurukbackback/modulecture/domain/storage/controller/ContentController.java
@@ -22,17 +22,17 @@ public class ContentController {
      * @param request   콘텐츠 메타데이터 요청 DTO
      * @return 성공 시 HTTP 200 응답
      */
-    @PostMapping("/upload")
-    public ResponseEntity<Void> uploadContent(
-            @RequestParam("videoFile") MultipartFile videoFile,
-            @ModelAttribute UploadContentRequestDto request) {
-        try {
-            contentService.uploadContent(videoFile, request);
-            return ResponseEntity.ok().build();
-        } catch (Exception e) {
-            throw new ContentUploadException();
-        }
-    }
+//    @PostMapping("/upload")
+//    public ResponseEntity<Void> uploadContent(
+//            @RequestParam("videoFile") MultipartFile videoFile,
+//            @ModelAttribute UploadContentRequestDto request) {
+//        try {
+//            contentService.uploadContent(request);
+//            return ResponseEntity.ok().build();
+//        } catch (Exception e) {
+//            throw new ContentUploadException();
+//        }
+//    }
 
     // 멀티파트 업로드 구현 (구현 중)
     // /**

--- a/src/main/java/com/sudurukbackback/modulecture/domain/storage/dto/request/UploadContentRequestDto.java
+++ b/src/main/java/com/sudurukbackback/modulecture/domain/storage/dto/request/UploadContentRequestDto.java
@@ -2,12 +2,12 @@ package com.sudurukbackback.modulecture.domain.storage.dto.request;
 
 import lombok.Data;
 import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 @Getter
 public class UploadContentRequestDto {
     private Long lectureId;
-    private List<Long> categoryIds;
-    private String videoUrl;
+    private MultipartFile file;
 }

--- a/src/main/java/com/sudurukbackback/modulecture/domain/storage/service/ContentService.java
+++ b/src/main/java/com/sudurukbackback/modulecture/domain/storage/service/ContentService.java
@@ -27,11 +27,11 @@ public class ContentService {
     /**
      * 콘텐츠를 업로드하고 처리합니다.
      *
-     * @param videoFile 업로드할 비디오 파일
      * @param request   콘텐츠 생성 요청 DTO
      */
     @Transactional
-    public void uploadContent(MultipartFile videoFile, UploadContentRequestDto request) {
+    public void uploadContent(Long lectureId, MultipartFile videoFile) {
+
         try {
             // 1. 비디오 파일을 로컬에 저장
             String localVideoPath = fileService.saveVideoFileLocally(videoFile);
@@ -56,7 +56,7 @@ public class ContentService {
 
             // 7. Content 엔티티 생성
             Content content = Content.builder()
-                    .lectureId(request.getLectureId())
+                    .lectureId(lectureId)
                     .videoUrl(videoUrl)
                     .imageUrl(imageUrl)
                     .duration(duration)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
     username: ${spring.datasource.username}
     password: ${spring.datasource.password}
     driver-class-name: com.mysql.cj.jdbc.Driver
-
+  
 cloud:
   aws:
     region: ${cloud.aws.region}


### PR DESCRIPTION
## 변경 사항
[//]: # (이 PR에서 어떤점들이 변경되었는지 기술. 가급적이면 as-is, to-be를 활용해서 작성)

[//]: # (현재 구현되어 있는 사항, 현재의 문제점 또는 한계, 변경 전의 기능이나 로직 설명)
### AS-IS

- Category 엔티티 추가
- Lecture 엔티티 수정
(videoUrl, imageUrl, duration 삭제)

- Lecture - Content 로직 추가
(createLecture API 파라미터에 Authentication 추가)
(Authentication Principal을 통해 userId를 가져오는 형태)
(강의 수정 Service단에서 videoUrl, imageUrl 제거)

[//]: # (개선되거나 변경된 상태, 기대하는 결과, 새로운 기능 설명)
### TO-BE

- Lecture - Content 테이블은 다대다(N:N) 연관관계이나 관계형 데이터베이스에서는 지원하지 않음
(한 개의 강의는 여러 개의 카테고리를 가질 수 있다.)
(한 개의 카테고리는 여러 개의 강의를 포함할 수 있다.)
- 따라서, Lecture_Category 테이블을 따로 추가하여 관계를 명세해주는 것이 필요함(ERD 수정 완료)
- 해당 내용은 0303 중으로 업로드할 예정

<img width="850" alt="Screenshot 2025-03-03 at 2 56 29 AM" src="https://github.com/user-attachments/assets/abfad5c6-79a4-4af8-85f8-02ac5af51f79" />


---

## 테스트
[//]: # (본 변경사항이 테스트가 되었는지 기술)

- [ ] 테스트 코드
- [ ] API 테스트 