### PR TITLE
[#116] feat : search도메인 추가 build.gradle 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
 		implementation 'org.springframework.boot:spring-boot-starter-batch'
 		implementation 'org.springframework.boot:spring-boot-starter-data-redis' // Redis
 
+		// Elasticsearch
+		implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch' // 서치 도메인
+
 		// AWS SDK for Java v2 dependencies
 		implementation platform('software.amazon.awssdk:bom:2.30.13') // AWS SDK BOM (의존성 버전 관리를 위한 Bill of Materials)
 		implementation 'software.amazon.awssdk:s3' // AWS S3 SDK (파일 업로드, 다운로드, 삭제 등 S3 연동)

--- a/src/main/java/com/sudurukbackback/modulecture/domain/search/controller/LectureSearchController.java
+++ b/src/main/java/com/sudurukbackback/modulecture/domain/search/controller/LectureSearchController.java
@@ -1,0 +1,22 @@
+package com.sudurukbackback.modulecture.domain.search.controller;
+
+import com.sudurukbackback.modulecture.domain.search.document.LectureDocument;
+import com.sudurukbackback.modulecture.domain.search.service.LectureSearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/search/lectures")
+@RequiredArgsConstructor
+public class LectureSearchController {
+
+    private final LectureSearchService lectureSearchService;
+
+    @GetMapping
+    public ResponseEntity<List<LectureDocument>> search(@RequestParam String keyword) {
+        return ResponseEntity.ok(lectureSearchService.search(keyword));
+    }
+}

--- a/src/main/java/com/sudurukbackback/modulecture/domain/search/document/LectureDocument.java
+++ b/src/main/java/com/sudurukbackback/modulecture/domain/search/document/LectureDocument.java
@@ -1,0 +1,20 @@
+package com.sudurukbackback.modulecture.domain.search.document;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Document(indexName = "lectures")
+public class LectureDocument {
+    @Id
+    private Long id;
+    private String title;
+    private String description;
+    private String instructor;
+    private String category;
+}

--- a/src/main/java/com/sudurukbackback/modulecture/domain/search/repository/LectureSearchRepository.java
+++ b/src/main/java/com/sudurukbackback/modulecture/domain/search/repository/LectureSearchRepository.java
@@ -1,0 +1,10 @@
+package com.sudurukbackback.modulecture.domain.search.repository;
+
+import com.sudurukbackback.modulecture.domain.search.document.LectureDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+import java.util.List;
+
+public interface LectureSearchRepository extends ElasticsearchRepository<LectureDocument, Long> {
+    List<LectureDocument> findByTitleContaining(String keyword);
+}

--- a/src/main/java/com/sudurukbackback/modulecture/domain/search/service/LectureSearchService.java
+++ b/src/main/java/com/sudurukbackback/modulecture/domain/search/service/LectureSearchService.java
@@ -1,0 +1,34 @@
+package com.sudurukbackback.modulecture.domain.search.service;
+
+import com.sudurukbackback.modulecture.domain.lecture.entity.Lecture;
+import com.sudurukbackback.modulecture.domain.search.document.LectureDocument;
+import com.sudurukbackback.modulecture.domain.search.repository.LectureSearchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LectureSearchService {
+
+    private final LectureSearchRepository lectureSearchRepository;
+
+    public List<LectureDocument> search(String keyword) {
+        return lectureSearchRepository.findByTitleContaining(keyword);
+    }
+
+    public void save(Lecture lecture) {
+        LectureDocument doc = LectureDocument.builder()
+                .id(lecture.getId())
+                .title(lecture.getTitle())
+                .description(lecture.getDescription())
+                .build();
+
+        lectureSearchRepository.save(doc);
+    }
+
+    public void delete(Long id) {
+        lectureSearchRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
## 추가 사항
[//]: # search 도메인 생성 및 Elasticsearch 전용 구성

LectureDocument, LectureSearchRepository, LectureSearchService, LectureSearchController 추가

LectureService에 Elasticsearch 연동 로직 추가

---


- [ ] 테스트 코드
- [ ] API 테스트 